### PR TITLE
fix(discussion): pass gid to discussion detail API for group routes

### DIFF
--- a/hoj-vue/src/common/api.js
+++ b/hoj-vue/src/common/api.js
@@ -731,11 +731,13 @@ const ojApi = {
     })
   },
 
-  getDiscussion(did) {
+  getDiscussion(did, gid) {
+    const params = { did };
+    if (gid !== undefined && gid !== null && gid !== '') {
+      params.gid = gid;
+    }
     return ajax("/api/get-discussion-detail", 'get', {
-      params: {
-        did
-      }
+      params
     })
   },
 

--- a/hoj-vue/src/views/oj/discussion/discussion.vue
+++ b/hoj-vue/src/views/oj/discussion/discussion.vue
@@ -258,7 +258,8 @@ export default {
       this.routeName = this.$route.name;
       this.discussionID = this.$route.params.discussionID || '';
       this.loading = true;
-      api.getDiscussion(this.discussionID).then(
+      const gid = this.$route.params.groupID || '';
+      api.getDiscussion(this.discussionID, gid).then(
         (res) => {
           this.discussion = res.data.data;
           this.changeDomTitle({ title: this.discussion.title });


### PR DESCRIPTION
Problem: Discussion details page in group routes did not load post content while comments loaded.

Root cause: The frontend did not pass groupID (gid) to /api/get-discussion-detail when visiting /group/:groupID/discussion-detail/:discussionID. Backend expects gid for proper scoping/auth, so it returned no content.

Fix: 
- api.getDiscussion now accepts optional gid and includes it in params when present.
- discussion.vue passes this..params.groupID to api.getDiscussion.

Impact: 
- Group discussion details now display the post content correctly.
- Non-group discussion details are unaffected.

Tested by navigating both group and non-group discussion detail routes and verifying content and interactions (like/edit/report) still work as before.